### PR TITLE
Fix step name consistency

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: set up JDK 11
+    - name: set up JDK
       uses: actions/setup-java@v3
       with:
         java-version: '17'


### PR DESCRIPTION
The step name is not consistent with the configuration inside of the step. The name claims JDK 11, but the `java-version` is actually 17.